### PR TITLE
Fix JitPack repository configuration for Serenegiant dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,14 @@ android {
     }
 }
 
+repositories {
+    google()
+    mavenCentral()
+    maven {
+        url = uri("https://jitpack.io")
+    }
+}
+
 dependencies {
     implementation(libs.appcompat)
     implementation(libs.material)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,3 +2,13 @@
 plugins {
     alias(libs.plugins.android.application) apply false
 }
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,10 +13,13 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://jitpack.io")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add the JitPack repository to the global, project, and module repository blocks so the Serenegiant dependency resolves
- switch repository mode to prefer project repositories while keeping the shared repository list in settings

## Testing
- ./gradlew assembleDebug *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e636b046c4832596e04db0e2a35c0a