### PR TITLE
Update Serenegiant dependency to JitPack libcommon

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ repositories {
 dependencies {
     implementation(libs.appcompat)
     implementation(libs.material)
-    implementation("com.serenegiant:common:2.12.4")
+    implementation("com.github.saki4510t:libcommon:9.1.6.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)


### PR DESCRIPTION
## Summary
- switch the Serenegiant dependency to the JitPack-hosted libcommon artifact

## Testing
- ./gradlew build *(fails: Unable to download Gradle distribution due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e63aef22d0832582c5eec53ee96571