### PR TITLE
Configure project to use local libcommon module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ repositories {
 dependencies {
     implementation(libs.appcompat)
     implementation(libs.material)
-    implementation("com.github.saki4510t:libcommon:9.1.6.0")
+    implementation(project(":libcommon"))
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,3 +25,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "USBPreviewLenovo"
 include(":app")
+include(":libcommon")
+project(":libcommon").projectDir = File("C:/Users/78yuu/AndroidStudioProjects/USBPreviewLenovo/libcommon")


### PR DESCRIPTION
## Summary
- register the libcommon module in settings.gradle.kts and point it to the local directory
- update the app module to depend on the local libcommon project instead of the remote artifact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6fcf98390832585fb760a35c69b56