### PR TITLE
Fix libcommon Gradle configuration

### DIFF
--- a/C:/Users/78yuu/AndroidStudioProjects/USBPreviewLenovo/libcommon/build.gradle.kts
+++ b/C:/Users/78yuu/AndroidStudioProjects/USBPreviewLenovo/libcommon/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "jp.ubiq.usbpreviewlenovo.libcommon"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 34
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}


### PR DESCRIPTION
## Summary
- update the libcommon module build script to apply the Android library plugin without an explicit version declaration
- configure the module to use SDK 34 values and Java 17 compatibility to match the project toolchain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6febb61a883258ef8b22db8e26f75