### PR TITLE
Simplify libcommon plugin declaration

### DIFF
--- a/C:/Users/78yuu/AndroidStudioProjects/USBPreviewLenovo/libcommon/build.gradle.kts
+++ b/C:/Users/78yuu/AndroidStudioProjects/USBPreviewLenovo/libcommon/build.gradle.kts
@@ -1,4 +1,3 @@
-// Configure libcommon without declaring a redundant Android Gradle Plugin version so it inherits from the root build.
 plugins {
     id("com.android.library")
 }


### PR DESCRIPTION
## Summary
- remove the redundant comment above the libcommon plugin declaration so the module cleanly inherits the AGP version from the root build

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e702f93de08325a60267e2a6566b01